### PR TITLE
fix manifest.json cause 1.21.0 didn't run

### DIFF
--- a/Chat Ranks+/manifest.json
+++ b/Chat Ranks+/manifest.json
@@ -47,7 +47,7 @@
 		}
 	],
 	"dependencies": [
-		{"module_name": "@minecraft/server","version": "1.11.0-beta"},
+		{"module_name": "@minecraft/server","version": "1.11.0"},
 		{"module_name": "@minecraft/server-ui","version": "1.1.0"}
 	]
 }


### PR DESCRIPTION
```
[2024-06-15 11:33:09:122 ERROR] [Scripting] Plugin [┬º8[┬ºb Chat Ranks+ ┬º8]] - module [┬º8[┬ºb Chat Ranks+ ┬º8] - 1.0.0] requesting invalid module version [@minecraft/server - 1.11.0-beta].
Available versions:
@minecraft/server - 0.1.0
@minecraft/server - 1.0.0
@minecraft/server - 1.1.0
@minecraft/server - 1.2.0
@minecraft/server - 1.3.0
@minecraft/server - 1.4.0
@minecraft/server - 1.5.0
@minecraft/server - 1.6.0
@minecraft/server - 1.7.0
@minecraft/server - 1.8.0
@minecraft/server - 1.9.0
@minecraft/server - 1.10.0
@minecraft/server - 1.11.0
@minecraft/server - 1.12.0-beta
```
https://learn.microsoft.com/id-id/minecraft/creator/scriptapi/minecraft/server/minecraft-server?view=minecraft-bedrock-stable